### PR TITLE
Fixes the display of the desired vanity key

### DIFF
--- a/vanity.c
+++ b/vanity.c
@@ -147,7 +147,7 @@ int main(int argc, char** argv) {
     printf("[*] Searching for: 0x...");
     int i;
     for(i = 0; i < vlen; i++)
-        printf("%02x", vanity[i]);
+        printf("%c", vanity[i]);
     printf("\n");
 
     uint32_t limit; {


### PR DESCRIPTION
The printf format string was printing the hex value of the hex character code rather than just reprinting the character.